### PR TITLE
fix: use suggested prefix `docs` for conventional commit pull request titles

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
           types: |
             chore
             coverage
-            doc
+            docs
             feat
             fix
             refactor


### PR DESCRIPTION
[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) suggest `docs` as prefix for documentation changes.