### PR TITLE
docs: change slogan

### DIFF
--- a/Source/Testably.Architecture.Testing/Testably.Architecture.Testing.csproj
+++ b/Source/Testably.Architecture.Testing/Testably.Architecture.Testing.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<RootNamespace>Testably.Architecture.Testing</RootNamespace>
-		<Description>Enforce architectural rules by writing expectations as unit tests.</Description>
+		<Description>Enforce architectural rules by documenting expectations as tests.</Description>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>
 	</PropertyGroup>
 


### PR DESCRIPTION
Change slogan to `Enforce architectural rules by documenting expectations as tests.`