### PR TITLE
feat: exclude system assemblies

### DIFF
--- a/Source/Testably.Architecture.Testing/ExtensionsForIExpectation.cs
+++ b/Source/Testably.Architecture.Testing/ExtensionsForIExpectation.cs
@@ -12,8 +12,20 @@ namespace Testably.Architecture.Testing;
 public static class ExtensionsForIExpectation
 {
 	/// <summary>
-	///     Defines expectations on all loaded assemblies from the current <see cref="System.AppDomain.CurrentDomain" />
+	///     Defines expectations on all loaded assemblies from the current <see cref="System.AppDomain.CurrentDomain" />.
 	/// </summary>
+	/// <param name="this">The <see cref="IExpectation" />.</param>
+	/// <param name="predicate">(optional) A predicate to filter the assemblies.</param>
+	/// <param name="excludeSystemAssemblies">
+	///     Flag, indicating if system assemblies should be filtered out.
+	///     <para />
+	///     If set to <see langword="true" /> (default value), no assemblies starting with<br />
+	///     - <c>System</c><br />
+	///     - <c>mscorlib</c><br />
+	///     - <c>xunit</c><br />
+	///     are loaded.<br />
+	///     Otherwise all assemblies matching the <paramref name="predicate" /> are loaded.
+	/// </param>
 	public static IFilterableAssemblyExpectation AllLoadedAssemblies(
 		this IExpectation @this,
 		Func<Assembly, bool>? predicate = null,
@@ -29,11 +41,9 @@ public static class ExtensionsForIExpectation
 	}
 
 	/// <summary>
-	///     Defines expectations on all types from all loaded assemblies from the current
-	///     <see cref="System.AppDomain.CurrentDomain" />
+	///     Defines expectations on all types from
+	///     <see cref="AllLoadedAssemblies(IExpectation, Func{Assembly,bool},bool)" />.
 	/// </summary>
-	/// <param name="this"></param>
-	/// <returns></returns>
 	public static IFilterableTypeExpectation AllLoadedTypes(this IExpectation @this)
 	{
 		return @this.AllLoadedAssemblies().Types;
@@ -47,7 +57,8 @@ public static class ExtensionsForIExpectation
 		=> @this.Assembly(typeof(TAssembly).Assembly);
 
 	/// <summary>
-	///     Defines expectations on all loaded assemblies that match the <paramref name="wildcardCondition" />.
+	///     Defines expectations on <see cref="AllLoadedAssemblies(IExpectation, Func{Assembly,bool},bool)" />
+	///     that match the <paramref name="wildcardCondition" />.
 	/// </summary>
 	/// <param name="this">The <see cref="IExpectation" />.</param>
 	/// <param name="wildcardCondition">

--- a/Source/Testably.Architecture.Testing/ExtensionsForIExpectation.cs
+++ b/Source/Testably.Architecture.Testing/ExtensionsForIExpectation.cs
@@ -20,8 +20,8 @@ public static class ExtensionsForIExpectation
 	///     Flag, indicating if system assemblies should be filtered out.
 	///     <para />
 	///     If set to <see langword="true" /> (default value), no assemblies starting with<br />
-	///     - <c>System</c><br />
 	///     - <c>mscorlib</c><br />
+	///     - <c>System</c><br />
 	///     - <c>xunit</c><br />
 	///     are loaded.<br />
 	///     Otherwise all assemblies matching the <paramref name="predicate" /> are loaded.

--- a/Source/Testably.Architecture.Testing/Internal/ExpectationSettings.cs
+++ b/Source/Testably.Architecture.Testing/Internal/ExpectationSettings.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Testably.Architecture.Testing.Internal;
+
+internal static class ExpectationSettings
+{
+	/// <summary>
+	///     The list of <see cref="Assembly"/>s to exclude from the current domain.
+	/// </summary>
+	public static readonly List<string> ExcludedSystemAssemblies = new()
+	{
+		"mscorlib",
+		"System",
+		"xunit"
+	};
+
+	public static bool IsExcluded(Assembly assembly)
+	{
+		return ExcludedSystemAssemblies.Any(
+			       excludedName => assembly.FullName?.StartsWith(
+				       excludedName,
+				       StringComparison.InvariantCulture) == true);
+	}
+}

--- a/Tests/Testably.Architecture.Testing.Tests/ExtensionsForIExpectationTests.cs
+++ b/Tests/Testably.Architecture.Testing.Tests/ExtensionsForIExpectationTests.cs
@@ -1,17 +1,69 @@
 ﻿using FluentAssertions;
+using System.Collections.Generic;
+using Testably.Architecture.Testing.Internal;
+using Testably.Architecture.Testing.TestErrors;
 using Xunit;
 
 namespace Testably.Architecture.Testing.Tests;
 
 public sealed class ExtensionsForIExpectationTests
 {
-	[Fact]
-	public void AssembliesMatching_FoundMatch_ShouldIncludeAssembly()
-	{
-		IFilterableAssemblyExpectation sut = Expect.That
-			.AssembliesMatching("*Architecture.Testing");
+	#region Test Setup
 
-		ITestResult<IAssemblyExpectation> result = sut.ShouldSatisfy(_ => false);
+	public static IEnumerable<object[]> ExcludedSystemAssemblies
+	{
+		get
+		{
+			foreach (string excludedSystemAssembly in ExpectationSettings.ExcludedSystemAssemblies)
+			{
+				yield return new object[]
+				{
+					excludedSystemAssembly
+				};
+			}
+		}
+	}
+
+	#endregion
+
+	[Theory]
+	[MemberData(nameof(ExcludedSystemAssemblies))]
+	public void AllLoadedAssemblies_ShouldExcludeAssemblyStartingWith(string assemblyPrefix)
+	{
+		IFilterableAssemblyExpectation reference =
+			Expect.That.AllLoadedAssemblies(excludeSystemAssemblies: false);
+		TestError[] referenceCount = reference.ShouldSatisfy(_ => false).Errors;
+
+		IFilterableAssemblyExpectation sut = Expect.That.AllLoadedAssemblies();
+
+		TestError[] result = sut.ShouldSatisfy(_ => false).Errors;
+#if !NCRUNCH
+		referenceCount.Should().Contain(
+			e => e.ToString().Contains($"'{assemblyPrefix}"),
+			$"assemblies with prefix '{assemblyPrefix}' should be excluded");
+#endif
+		result.Should().NotContain(e => e.ToString().Contains($"'{assemblyPrefix}"));
+	}
+
+	[Fact]
+	public void AllLoadedAssemblies_ShouldFilterOutSystemAssemblies()
+	{
+		IFilterableAssemblyExpectation reference =
+			Expect.That.AllLoadedAssemblies(excludeSystemAssemblies: false);
+		TestError[] referenceCount = reference.ShouldSatisfy(_ => false).Errors;
+
+		IFilterableAssemblyExpectation sut = Expect.That.AllLoadedAssemblies();
+
+		TestError[] result = sut.ShouldSatisfy(_ => false).Errors;
+		result.Length.Should().BeLessThan(referenceCount.Length);
+	}
+
+	[Fact]
+	public void AllLoadedTypes_ShouldNotBeEmpty()
+	{
+		IFilterableTypeExpectation sut = Expect.That.AllLoadedTypes();
+
+		ITestResult<ITypeExpectation> result = sut.ShouldSatisfy(_ => false);
 
 		result.Errors.Should().NotBeEmpty();
 	}
@@ -27,5 +79,16 @@ public sealed class ExtensionsForIExpectationTests
 		ITestResult<IAssemblyExpectation> result = sut.ShouldSatisfy(_ => false);
 
 		(result.Errors.Length > 0).Should().Be(ignoreCase);
+	}
+
+	[Fact]
+	public void AssembliesMatching_FoundMatch_ShouldIncludeAssembly()
+	{
+		IFilterableAssemblyExpectation sut = Expect.That
+			.AssembliesMatching("*Architecture.Testing.Tests");
+
+		ITestResult<IAssemblyExpectation> result = sut.ShouldSatisfy(_ => false);
+
+		result.Errors.Should().NotBeEmpty();
 	}
 }

--- a/Tests/Testably.Architecture.Testing.Tests/Internal/AssemblyExpectationTests.cs
+++ b/Tests/Testably.Architecture.Testing.Tests/Internal/AssemblyExpectationTests.cs
@@ -57,10 +57,10 @@ public sealed class AssemblyExpectationTests
 		IFilterableAssemblyExpectation sut = Expect.That.AllLoadedAssemblies();
 
 		ITestResult<IAssemblyExpectation> result = sut
-			.Which(p => p.GetName().Name?.StartsWith("System") != true)
+			.Which(p => p.GetName().Name?.StartsWith("Testably") != true)
 			.ShouldSatisfy(_ => false);
 
 		result.Errors.Length.Should().BeLessThan(allAssembliesCount);
-		result.Errors.Should().OnlyContain(e => !e.ToString().Contains("'System"));
+		result.Errors.Should().OnlyContain(e => !e.ToString().Contains("'Testably"));
 	}
 }

--- a/Tests/Testably.Architecture.Testing.Tests/TestErrors/DependencyTestErrorTests.cs
+++ b/Tests/Testably.Architecture.Testing.Tests/TestErrors/DependencyTestErrorTests.cs
@@ -86,6 +86,7 @@ public sealed class DependencyTestErrorTests
 				.Skip(1)
 				.Take(assemblyReferences.Length - 2)
 				.Select(x => x.Name))}'");
+		result.Should().NotContain($", '{assemblyReferences.Last().Name}'");
 		result.Should().Contain($"and '{assemblyReferences.Last().Name}'");
 	}
 


### PR DESCRIPTION
If not explicitely specified otherwise exclude loading system assemblies.
System assemblies are assemblies which name starts with on of the following prefixes:
- mscorlib
- System
- xunit