### PR TITLE
feat: add extension methods for `ITypeExpectation` (2)

### DIFF
--- a/Source/Testably.Architecture.Testing/ExtensionsForITypeExpectation.cs
+++ b/Source/Testably.Architecture.Testing/ExtensionsForITypeExpectation.cs
@@ -49,6 +49,38 @@ public static class ExtensionsForITypeExpectation
 				$"Type '{type.Name}' should have correct attribute '{typeof(TAttribute).Name}'."));
 
 	/// <summary>
+	///     Expect the types to inherit from <typeparamref name="TBase" />.
+	/// </summary>
+	/// <param name="this">The <see cref="ITypeExpectation" />.</param>
+	/// <param name="forceDirect">
+	///     If set to <see langword="false" /> (default value), the <typeparamref name="TBase" />
+	///     can be anywhere in the inheritance tree, otherwise if set to <see langword="true" /> requires the
+	///     <typeparamref name="TBase" /> to be the direct parent.
+	/// </param>
+	public static ITestResult<ITypeExpectation> ShouldInheritFrom<TBase>(
+		this ITypeExpectation @this,
+		bool forceDirect = false)
+		=> @this.ShouldInheritFrom(typeof(TBase), forceDirect);
+
+	/// <summary>
+	///     Expect the types to inherit from <paramref name="baseType" />.
+	/// </summary>
+	/// <param name="this">The <see cref="ITypeExpectation" />.</param>
+	/// <param name="baseType">The base type which should be inherited from.</param>
+	/// <param name="forceDirect">
+	///     If set to <see langword="false" /> (default value), the <paramref name="baseType" />
+	///     can be anywhere in the inheritance tree, otherwise if set to <see langword="true" /> requires the
+	///     <paramref name="baseType" /> to be the direct parent.
+	/// </param>
+	public static ITestResult<ITypeExpectation> ShouldInheritFrom(
+		this ITypeExpectation @this,
+		Type baseType,
+		bool forceDirect = false)
+		=> @this.ShouldSatisfy(type => type.Inherits(baseType, forceDirect),
+			type => new TypeTestError(type,
+				$"Type '{type.Name}' should{(forceDirect ? " directly" : "")} inherit from '{baseType.Name}'."));
+
+	/// <summary>
 	///     Expect the <see cref="MemberInfo.Name" /> of the types to match the given <paramref name="pattern" />.
 	/// </summary>
 	/// <param name="this">The <see cref="ITypeExpectation" />.</param>
@@ -88,6 +120,38 @@ public static class ExtensionsForITypeExpectation
 		=> @this.ShouldSatisfy(type => !type.HasAttribute(predicate, inherit),
 			type => new TypeTestError(type,
 				$"Type '{type.Name}' should not have correct attribute '{typeof(TAttribute).Name}'."));
+
+	/// <summary>
+	///     Expect the types to inherit from <typeparamref name="TBase" />.
+	/// </summary>
+	/// <param name="this">The <see cref="ITypeExpectation" />.</param>
+	/// <param name="forceDirect">
+	///     If set to <see langword="false" /> (default value), the <typeparamref name="TBase" />
+	///     can be anywhere in the inheritance tree, otherwise if set to <see langword="true" /> requires the
+	///     <typeparamref name="TBase" /> to be the direct parent.
+	/// </param>
+	public static ITestResult<ITypeExpectation> ShouldNotInheritFrom<TBase>(
+		this ITypeExpectation @this,
+		bool forceDirect = false)
+		=> @this.ShouldNotInheritFrom(typeof(TBase), forceDirect);
+
+	/// <summary>
+	///     Expect the types to inherit from <paramref name="baseType" />.
+	/// </summary>
+	/// <param name="this">The <see cref="ITypeExpectation" />.</param>
+	/// <param name="baseType">The base type which should be inherited from.</param>
+	/// <param name="forceDirect">
+	///     If set to <see langword="false" /> (default value), the <paramref name="baseType" />
+	///     can be anywhere in the inheritance tree, otherwise if set to <see langword="true" /> requires the
+	///     <paramref name="baseType" /> to be the direct parent.
+	/// </param>
+	public static ITestResult<ITypeExpectation> ShouldNotInheritFrom(
+		this ITypeExpectation @this,
+		Type baseType,
+		bool forceDirect = false)
+		=> @this.ShouldSatisfy(type => !type.Inherits(baseType, forceDirect),
+			type => new TypeTestError(type,
+				$"Type '{type.Name}' should not{(forceDirect ? " directly" : "")} inherit from '{baseType.Name}'."));
 
 	/// <summary>
 	///     Expect the <see cref="MemberInfo.Name" /> of the types to not match the given <paramref name="pattern" />.

--- a/Tests/Testably.Architecture.Testing.Tests/ExtensionsForITypeExpectationTests.ShouldInheritFrom.cs
+++ b/Tests/Testably.Architecture.Testing.Tests/ExtensionsForITypeExpectationTests.ShouldInheritFrom.cs
@@ -1,0 +1,248 @@
+﻿using FluentAssertions;
+using System;
+using Testably.Architecture.Testing.TestErrors;
+using Xunit;
+
+namespace Testably.Architecture.Testing.Tests;
+
+public sealed partial class ExtensionsForITypeExpectationTests
+{
+	public sealed class ShouldInherit
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldInheritFrom_ForceDirect_WithClass_ShouldConsiderParameter(bool forceDirect)
+		{
+			Type type = typeof(FooImplementor2);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom<FooBase>(
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(!forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldInheritFrom_ForceDirect_WithGenericClass_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(GenericFooImplementor2<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom(
+				typeof(IGenericFooInterface<>),
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(!forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldInheritFrom_ForceDirect_WithGenericClassAndInterface_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(GenericFooImplementor2<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom(typeof(IFooInterface),
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(!forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldInheritFrom_ForceDirect_WithGenericInterface_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(GenericFooImplementor2<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom(typeof(GenericFooClass<>),
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(!forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldInheritFrom_ForceDirect_WithInterface_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(FooImplementor2);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom<IFooInterface>(
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(!forceDirect);
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithClass_ShouldBeSatisfied()
+		{
+			Type type = typeof(FooImplementor3);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom<FooBase>();
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithGenericClass_ShouldBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldInheritFrom(typeof(GenericFooClass<>));
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithGenericInterface_ShouldBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldInheritFrom(typeof(IGenericFooInterface<>));
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithInterface_ShouldBeSatisfied()
+		{
+			Type type = typeof(FooImplementor3);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom<IFooInterface>();
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithoutClass_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom<BarClass>();
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithoutGenericClass_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldInheritFrom(typeof(GenericBarClass<>));
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithoutGenericInterface_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldInheritFrom(typeof(IOtherGenericFooInterface<>));
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldInheritFrom_WithoutInterface_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldInheritFrom<IOtherFooInterface>();
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		private abstract class FooBase
+		{
+		}
+
+		private class FooImplementor1 : FooBase, IFooInterface
+		{
+		}
+
+		private class FooImplementor2 : FooImplementor1
+		{
+		}
+
+		private class FooImplementor3 : FooImplementor2
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private class GenericFooClass<T>
+		{
+		}
+
+		private class GenericFooImplementor1<T> : GenericFooClass<T>, IGenericFooInterface<T>,
+			IFooInterface
+		{
+		}
+
+		private class GenericFooImplementor2<T> : GenericFooImplementor1<T>
+		{
+		}
+
+		private class GenericFooImplementor3<T> : GenericFooImplementor2<T>
+		{
+		}
+
+		private interface IFooInterface
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private interface IGenericFooInterface<T>
+		{
+		}
+
+		private interface IOtherFooInterface
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private interface IOtherGenericFooInterface<T>
+		{
+		}
+
+		private abstract class BarClass
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private class GenericBarClass<T>
+		{
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Testing.Tests/ExtensionsForITypeExpectationTests.ShouldNotInheritFrom.cs
+++ b/Tests/Testably.Architecture.Testing.Tests/ExtensionsForITypeExpectationTests.ShouldNotInheritFrom.cs
@@ -1,0 +1,251 @@
+﻿using FluentAssertions;
+using System;
+using Testably.Architecture.Testing.TestErrors;
+using Xunit;
+
+namespace Testably.Architecture.Testing.Tests;
+
+public sealed partial class ExtensionsForITypeExpectationTests
+{
+	public sealed class ShouldNotInheritFrom
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotInheritFrom_ForceDirect_WithClass_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(FooImplementor2);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom<FooBase>(
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotInheritFrom_ForceDirect_WithGenericClass_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(GenericFooImplementor2<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom(
+				typeof(IGenericFooInterface<>),
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void
+			ShouldNotInheritFrom_ForceDirect_WithGenericClassAndInterface_ShouldConsiderParameter(
+				bool forceDirect)
+		{
+			Type type = typeof(GenericFooImplementor2<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom(typeof(IFooInterface),
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotInheritFrom_ForceDirect_WithGenericInterface_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(GenericFooImplementor2<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom(
+				typeof(GenericFooClass<>),
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(forceDirect);
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotInheritFrom_ForceDirect_WithInterface_ShouldConsiderParameter(
+			bool forceDirect)
+		{
+			Type type = typeof(FooImplementor2);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom<IFooInterface>(
+				forceDirect: forceDirect);
+
+			result.IsSatisfied.Should().Be(forceDirect);
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithClass_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(FooImplementor3);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom<FooBase>();
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithGenericClass_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldNotInheritFrom(typeof(GenericFooClass<>));
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithGenericInterface_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldNotInheritFrom(typeof(IGenericFooInterface<>));
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithInterface_ShouldNotBeSatisfied()
+		{
+			Type type = typeof(FooImplementor3);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom<IFooInterface>();
+
+			result.IsSatisfied.Should().BeFalse();
+			result.Errors[0].Should().BeOfType<TypeTestError>()
+				.Which.Type.Should().Be(type);
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithoutClass_ShouldBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom<BarClass>();
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithoutGenericClass_ShouldBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldNotInheritFrom(typeof(GenericBarClass<>));
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithoutGenericInterface_ShouldBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation>
+				result = sut.ShouldNotInheritFrom(typeof(IOtherGenericFooInterface<>));
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ShouldNotInheritFrom_WithoutInterface_ShouldBeSatisfied()
+		{
+			Type type = typeof(GenericFooImplementor3<>);
+			IFilterableTypeExpectation sut = Expect.That.Type(type);
+
+			ITestResult<ITypeExpectation> result = sut.ShouldNotInheritFrom<IOtherFooInterface>();
+
+			result.IsSatisfied.Should().BeTrue();
+		}
+
+		private abstract class FooBase
+		{
+		}
+
+		private class FooImplementor1 : FooBase, IFooInterface
+		{
+		}
+
+		private class FooImplementor2 : FooImplementor1
+		{
+		}
+
+		private class FooImplementor3 : FooImplementor2
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private class GenericFooClass<T>
+		{
+		}
+
+		private class GenericFooImplementor1<T> : GenericFooClass<T>, IGenericFooInterface<T>,
+			IFooInterface
+		{
+		}
+
+		private class GenericFooImplementor2<T> : GenericFooImplementor1<T>
+		{
+		}
+
+		private class GenericFooImplementor3<T> : GenericFooImplementor2<T>
+		{
+		}
+
+		private interface IFooInterface
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private interface IGenericFooInterface<T>
+		{
+		}
+
+		private interface IOtherFooInterface
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private interface IOtherGenericFooInterface<T>
+		{
+		}
+
+		private abstract class BarClass
+		{
+		}
+
+		// ReSharper disable once UnusedTypeParameter
+		private class GenericBarClass<T>
+		{
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Testing.Tests/ExtensionsForTypeTests.cs
+++ b/Tests/Testably.Architecture.Testing.Tests/ExtensionsForTypeTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Testably.Architecture.Testing.Tests;
 
-public sealed class ExtensionsForType
+public sealed class ExtensionsForTypeTests
 {
 	[Fact]
 	public void HasAttribute_WithAttribute_ShouldReturnTrue()


### PR DESCRIPTION
Add the following extension methods:
- `ShouldInheritFrom` and `ShouldNotInheritFrom`

*Used [this answer for 'Check if a class is derived from a generic class'](https://stackoverflow.com/a/4897426) as an inspiration.*